### PR TITLE
Fix: Correct remaining Jinja2 template syntax errors

### DIFF
--- a/promethios_ui_surface/src/templates/integrity_check.html
+++ b/promethios_ui_surface/src/templates/integrity_check.html
@@ -24,8 +24,8 @@
                     <tr>
                         <td>{{ result.file_path }}</td>
                         <td><small>{{ result.expected_hash }}</small></td>
-                        <td><small>{{ result.calculated_hash | default(\'N/A\', true) }}</small></td>
-                        <td class="status-{{ result.status.lower().replace(\' \	enderline\', \'\') }}">
+                        <td><small>{{ result.calculated_hash | default("N/A", true) }}</small></td>
+                        <td class="status-{{ result.status.lower().replace(" ", "-") }}">
                             {{ result.status }}
                         </td>
                     </tr>

--- a/promethios_ui_surface/src/templates/replay.html
+++ b/promethios_ui_surface/src/templates/replay.html
@@ -5,13 +5,13 @@
 {% block content %}
     <h2>Manual Replay Initiation</h2>
 
-    <form method="post" action="{{ url_for(\'replay\') }}" class="filter-form">
+    <form method="post" action="{{ url_for("replay") }}" class="filter-form">
         <label for="scenario_id_or_log_file">Scenario ID / Log File Path:</label>
-        <input type="text" id="scenario_id_or_log_file" name="scenario_id_or_log_file" value="{{ request.form.get(\'scenario_id_or_log_file\", \"\") }}" required>
+        <input type="text" id="scenario_id_or_log_file" name="scenario_id_or_log_file" value="{{ request.form.get("scenario_id_or_log_file", "") }}" required>
         <small>Example: `deterministic_replay_input_audit_replay_test_20250513175517_30242d76.json` or a scenario ID.</small><br><br>
 
         <label for="loop_input_json_path">Path to loop_input.json (if applicable):</label>
-        <input type="text" id="loop_input_json_path" name="loop_input_json_path" value="{{ request.form.get(\'loop_input_json_path\") }}">
+        <input type="text" id="loop_input_json_path" name="loop_input_json_path" value="{{ request.form.get("loop_input_json_path") }}">
         <small>Optional. If your replay script uses a specific loop input file not inferred by scenario ID.</small><br><br>
         
         <button type="submit">Initiate Replay</button>


### PR DESCRIPTION
- Resolved TemplateSyntaxError in replay.html and integrity_check.html by removing backslash escapes from url_for() and default() filter calls.
- Ensured all Jinja2 expressions use standard double quotes for string literals within template tags.