### PR TITLE
Add start script and Express server for production deployment

### DIFF
--- a/phase_7_1_prototype/promethios-ui/package.json
+++ b/phase_7_1_prototype/promethios-ui/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "node server.js"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",
@@ -45,6 +46,7 @@
     "cmdk": "1.0.0",
     "date-fns": "^3.3.1",
     "embla-carousel-react": "^8.5.2",
+    "express": "^4.18.2",
     "framer-motion": "^12.14.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.364.0",

--- a/phase_7_1_prototype/promethios-ui/server.js
+++ b/phase_7_1_prototype/promethios-ui/server.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+
+// Serve static files from the dist directory
+app.use(express.static(path.join(__dirname, 'dist')));
+
+// For any other request, send the index.html file
+// This enables client-side routing
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+});
+
+// Use the PORT environment variable provided by Render.com
+// or default to 3000 for local development
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Overview

This PR adds a production start script and Express server to fix the deployment error on Render.com.

## Issues Fixed

1. **Missing Start Script Error**:
   - Added `start` script to package.json to resolve the `npm error Missing script: "start"` error
   - Implemented Express server to serve the built static files

## Changes

1. **Added Start Script**:
   - Updated `package.json` to include a `start` script that runs the Express server

2. **Implemented Express Server**:
   - Created `server.js` to serve the built static files from the `dist` directory
   - Added support for client-side routing by serving `index.html` for all routes
   - Configured the server to use the PORT environment variable provided by Render.com

3. **Added Dependencies**:
   - Added Express as a dependency for serving the production build

## Testing

The changes have been tested locally to ensure:
- The Express server correctly serves static files
- Client-side routing works properly
- The server listens on the correct port

## Deployment Instructions

1. Merge this PR
2. The deployment will automatically use the new start script
3. Monitor the deployment logs to confirm successful startup

These changes ensure the UI/UX application can be properly served in production on Render.com.