### PR TITLE
Fix server.js to use ES module syntax instead of CommonJS

### DIFF
--- a/phase_7_1_prototype/promethios-ui/server.js
+++ b/phase_7_1_prototype/promethios-ui/server.js
@@ -1,5 +1,12 @@
-const express = require('express');
-const path = require('path');
+// ES Module version of server.js
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// ES modules don't have __dirname, so we need to create it
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 const app = express();
 
 // Serve static files from the dist directory


### PR DESCRIPTION
## Overview

This PR fixes the ES module error that occurred after the previous deployment by updating server.js to use ES module syntax instead of CommonJS.

## Issues Fixed

1. **ES Module Compatibility Error**:
   - Fixed ReferenceError: require is not defined in ES module scope error
   - Converted CommonJS syntax to ES module syntax
   - Added proper handling for __dirname equivalent in ES modules

## Changes

1. **Updated server.js**:
   - Replaced require() with import statements
   - Added fileURLToPath to handle file paths in ES modules
   - Created __dirname equivalent using import.meta.url

## Testing

The changes ensure compatibility with the project's ES module configuration ("type": "module" in package.json).

## Deployment Instructions

1. Merge this PR
2. The deployment will automatically use the updated ES module compatible server
3. Monitor the deployment logs to confirm successful startup

This fix ensures the Express server can properly run in an ES module environment on Render.com.