### PR TITLE
Fix vite not found error by using npx in build script

### DIFF
--- a/phase_7_1_prototype/promethios-ui/package.json
+++ b/phase_7_1_prototype/promethios-ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "npx vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "start": "node server.js"


### PR DESCRIPTION
This PR fixes the "vite: not found" error in the deployment environment by:

1. Updating the build script in package.json to use `npx vite build` instead of just `vite build`

This ensures that the build process uses the locally installed Vite binary from node_modules rather than relying on a global installation, which is not available in the Render.com deployment environment.

This is a standard approach for deployment environments where dev dependencies are not globally available.