### PR TITLE
Fix build error by moving Vite plugins to dependencies

### DIFF
--- a/phase_7_1_prototype/promethios-ui/package.json
+++ b/phase_7_1_prototype/promethios-ui/package.json
@@ -41,6 +41,7 @@
     "@radix-ui/react-toggle-group": "^1.1.1",
     "@radix-ui/react-tooltip": "^1.1.6",
     "@types/react-router-dom": "^5.3.3",
+    "@vitejs/plugin-react": "^4.3.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.0",
@@ -61,6 +62,7 @@
     "sonner": "^1.7.2",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "vite": "^6.0.1",
     "vaul": "^1.1.2",
     "zod": "^3.24.1"
   },
@@ -69,7 +71,6 @@
     "@types/node": "^22.15.23",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
-    "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "10.4.20",
     "eslint": "^9.15.0",
     "eslint-plugin-react-hooks": "^5.0.0",
@@ -78,7 +79,6 @@
     "postcss": "8.4.49",
     "tailwindcss": "v3.4.16",
     "typescript": "~5.6.2",
-    "typescript-eslint": "^8.15.0",
-    "vite": "^6.0.1"
+    "typescript-eslint": "^8.15.0"
   }
 }


### PR DESCRIPTION
This PR fixes the "Cannot find package @vitejs/plugin-react" error in the deployment environment by:

1. Moving `@vitejs/plugin-react` from devDependencies to dependencies in package.json
2. Moving `vite` to dependencies to ensure it is available in the production environment

This is necessary because Render.com deployment environments do not install devDependencies by default, but these packages are required during the build process.

The build now completes successfully with these changes.