### PR TITLE
Fix: Add axios dependency to package.json

### DIFF
--- a/phase_7_1_prototype/promethios-ui/package.json
+++ b/phase_7_1_prototype/promethios-ui/package.json
@@ -43,6 +43,7 @@
     "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "10.4.20",
+    "axios": "^1.6.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.0",


### PR DESCRIPTION
## Description\n\nThis PR fixes the build error in the Phase 7.1 UI deployment:\n\n```\nRollup failed to resolve import "axios" from "/opt/render/project/src/phase_7_1_prototype/promethios-ui/src/services/liveObservers.ts"\n```\n\n## Changes\n\n- Added axios v1.6.7 to package.json dependencies\n\n## Testing\n\nAfter merging this PR, redeploy the UI on Render to verify the build succeeds.\n\n## Related Issues\n\nFixes the deployment error shown in the Render logs.