### PR TITLE
Fix: Update server.js to properly handle MIME types for JavaScript modules

### DIFF
--- a/phase_7_1_prototype/promethios-ui/server.js
+++ b/phase_7_1_prototype/promethios-ui/server.js
@@ -9,12 +9,27 @@ const __dirname = path.dirname(__filename);
 
 const app = express();
 
-// Serve static files from the dist directory
-app.use(express.static(path.join(__dirname, 'dist')));
+// Serve static files from the dist directory with proper MIME types
+app.use(express.static(path.join(__dirname, 'dist'), {
+  setHeaders: (res, path) => {
+    // Set correct MIME types for JavaScript modules
+    if (path.endsWith('.js')) {
+      res.set('Content-Type', 'application/javascript');
+    } else if (path.endsWith('.mjs')) {
+      res.set('Content-Type', 'application/javascript');
+    }
+  }
+}));
 
-// For any other request, send the index.html file
-// This enables client-side routing
-app.get('*', (req, res) => {
+// Only use the fallback for non-file requests
+// This prevents index.html from being served for JS module requests
+app.get('*', (req, res, next) => {
+  // Skip fallback for paths with file extensions (likely static assets)
+  if (req.path.includes('.')) {
+    return next();
+  }
+  
+  // For routes without extensions, serve index.html
   res.sendFile(path.join(__dirname, 'dist', 'index.html'));
 });
 


### PR DESCRIPTION
## Description\n\nThis PR fixes the blank screen issue after deployment where JavaScript modules were failing to load with a MIME type error:\n\n```\nFailed to load module script: expected a JavaScript module script but the server responded with a MIME type of "text/html". Strict MIME type checking is enforced for module scripts per HTML spec.\n```\n\n## Changes\n\n- Updated server.js to explicitly set the correct Content-Type headers for JavaScript files\n- Improved the SPA fallback logic to only apply to routes without file extensions\n- Prevents index.html from being served for JavaScript module requests\n\n## Testing\n\nAfter merging this PR, redeploy the UI on Render to verify that the application loads correctly without MIME type errors.\n\n## Related Issues\n\nFollows PR #72 which fixed the axios dependency issue. This PR addresses the blank screen that appeared after that fix.