### PR TITLE
Fix: Add ThemeProvider to main.tsx to resolve context error

### DIFF
--- a/phase_7_1_prototype/promethios-ui/src/main.tsx
+++ b/phase_7_1_prototype/promethios-ui/src/main.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { ThemeProvider } from './context/ThemeContext';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Description\n\nThis PR fixes the blank screen issue after deploying PR #71 and #74. The application was failing with the error:\n\n```\nError: useTheme must be used within a ThemeProvider\n```\n\n## Changes\n\n- Added ThemeProvider from context/ThemeContext.tsx to wrap the App component in main.tsx\n- This ensures all components that use the useTheme hook have access to the theme context\n\n## Testing\n\nAfter merging this PR, redeploy the UI on Render to verify that the application loads correctly without any context errors.\n\n## Related Issues\n\nFollows PR #74 which added the missing HomePage component. This PR addresses the blank screen that appeared after that fix due to missing ThemeProvider context.