### PR TITLE
Fix API key configuration to use VITE_ prefixed environment variables

### DIFF
--- a/phase_7_1_prototype/promethios-ui/public/cmu-playground/modules/apiClient.js
+++ b/phase_7_1_prototype/promethios-ui/public/cmu-playground/modules/apiClient.js
@@ -27,10 +27,10 @@ class APIClient {
         }
       },
       apiKeys: {
-        openai: this.getEnvironmentVariable('OPENAI_API_KEY'),
-        anthropic: this.getEnvironmentVariable('ANTHROPIC_API_KEY'),
-        cohere: this.getEnvironmentVariable('COHERE_API_KEY'),
-        huggingface: this.getEnvironmentVariable('HUGGINGFACE_API_KEY')
+        openai: this.getEnvironmentVariable('VITE_OPENAI_API_KEY'),
+        anthropic: this.getEnvironmentVariable('VITE_ANTHROPIC_API_KEY'),
+        cohere: this.getEnvironmentVariable('VITE_COHERE_API_KEY'),
+        huggingface: this.getEnvironmentVariable('VITE_HUGGINGFACE_API_KEY')
       }
     };
     
@@ -46,6 +46,11 @@ class APIClient {
    */
   getEnvironmentVariable(name) {
     try {
+      // Try to access from import.meta.env (Vite)
+      if (typeof import !== 'undefined' && import.meta && import.meta.env && import.meta.env[name]) {
+        return import.meta.env[name];
+      }
+      
       // Try to access from process.env (Node.js)
       if (typeof process !== 'undefined' && process.env && process.env[name]) {
         return process.env[name];


### PR DESCRIPTION
- Updated apiKeys configuration to use VITE_OPENAI_API_KEY, VITE_ANTHROPIC_API_KEY, etc.
- Updated getEnvironmentVariable method to support import.meta.env for Vite
- This should enable real API integration instead of falling back to preset responses