### PR TITLE
Fix critical syntax error in apiClient.js

### DIFF
--- a/phase_7_1_prototype/promethios-ui/public/cmu-playground/modules/apiClient.js
+++ b/phase_7_1_prototype/promethios-ui/public/cmu-playground/modules/apiClient.js
@@ -47,7 +47,7 @@ class APIClient {
   getEnvironmentVariable(name) {
     try {
       // Try to access from import.meta.env (Vite)
-      if (typeof import !== 'undefined' && import.meta && import.meta.env && import.meta.env[name]) {
+      if (import.meta && import.meta.env && import.meta.env[name]) {
         return import.meta.env[name];
       }
       


### PR DESCRIPTION
- Remove problematic 'typeof import !== undefined' check
- import.meta is always available in ES6 modules
- This fixes the 'Unexpected token !==' error preventing all JS modules from loading
- Restores full JavaScript functionality including event handlers and API integration