### PR TITLE
Fix syntax error: Remove invalid typeof import check in ES6 module

### DIFF
--- a/phase_7_1_prototype/promethios-ui/public/cmu-playground/modules/robustApiClient.js
+++ b/phase_7_1_prototype/promethios-ui/public/cmu-playground/modules/robustApiClient.js
@@ -10,7 +10,7 @@
 function getEnvironmentVariable(name) {
   try {
     // Strategy 1: Vite environment variables (if build process ran)
-    if (typeof import !== 'undefined' && import.meta && import.meta.env && import.meta.env[name]) {
+    if (import.meta && import.meta.env && import.meta.env[name]) {
       console.log(`✅ Found ${name} via import.meta.env`);
       return import.meta.env[name];
     }


### PR DESCRIPTION
- Fixed 'Unexpected token !==' error in robustApiClient.js
- Removed invalid 'typeof import !== undefined' check
- import.meta is always available in ES6 modules
- All JavaScript modules now pass syntax validation