### PR TITLE
Fix: Add missing /api/env endpoint to expose environment variables to frontend

### DIFF
--- a/phase_7_1_prototype/promethios-ui/server/api.js
+++ b/phase_7_1_prototype/promethios-ui/server/api.js
@@ -198,6 +198,37 @@ apiRouter.post('/governance', async (req, res) => {
 });
 
 /**
+ * GET /api/env
+ * Returns environment variables needed by the frontend
+ */
+apiRouter.get('/env', (req, res) => {
+  // Only expose specific environment variables to the frontend
+  // with both VITE_ and VTF_ prefixes
+  const envVars = {
+    // OpenAI
+    VITE_OPENAI_API_KEY: process.env.OPENAI_API_KEY || null,
+    VTF_OPENAI_API_KEY: process.env.OPENAI_API_KEY || null,
+    
+    // Anthropic
+    VITE_ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY || null,
+    VTF_ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY || null,
+    
+    // Cohere
+    VITE_COHERE_API_KEY: process.env.COHERE_API_KEY || null,
+    VTF_COHERE_API_KEY: process.env.COHERE_API_KEY || null,
+    
+    // HuggingFace
+    VITE_HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY || null,
+    VTF_HUGGINGFACE_API_KEY: process.env.HUGGINGFACE_API_KEY || null,
+  };
+  
+  res.json({
+    success: true,
+    env: envVars
+  });
+});
+
+/**
  * Get a demo response for development and testing
  * @param {string} role - Agent role
  * @param {string} scenario - Scenario ID


### PR DESCRIPTION
## Problem
The CMU Interactive Playground was stuck in demo mode despite having API keys configured because the `/api/env` endpoint was completely missing from the backend API implementation. When the frontend tried to fetch environment variables from this endpoint, it received an HTML 404 error page instead of the expected JSON response, resulting in a JSON parse error and fallback to demo mode.

## Solution
This PR adds the missing `/api/env` endpoint to the backend API in `api.js`. The new endpoint:

- Exposes API keys with both VITE_ and VTF_ prefixes for compatibility
- Returns environment variables in the expected JSON format with `success` and `env` properties
- Properly handles all required LLM provider keys (OpenAI, Anthropic, Cohere, HuggingFace)

## Testing
After deploying these changes, the CMU playground should:
1. Successfully fetch environment variables from the `/api/env` endpoint
2. Recognize the available API keys
3. Exit demo mode and use real LLM providers

This fix complements the previous PR that added support for both VITE_ and VTF_ prefixes in the frontend code.